### PR TITLE
Require bytes for bitfield

### DIFF
--- a/bitfield.go
+++ b/bitfield.go
@@ -6,4 +6,5 @@ type Bitfield interface {
 	SetBitAt(idx uint64, val bool)
 	Len() uint64
 	Count() uint64
+	Bytes() []byte
 }

--- a/bitvector.go
+++ b/bitvector.go
@@ -52,7 +52,7 @@ func (b Bitvector4) Count() uint64 {
 }
 
 // Bytes returns the bytes data representing the bitvector4. This method
-// bitmasks the underlying data to unsure that it is an accurate representation.
+// bitmasks the underlying data to ensure that it is an accurate representation.
 func (b Bitvector4) Bytes() []byte {
 	if len(b) == 0 {
 		return []byte{}

--- a/bitvector.go
+++ b/bitvector.go
@@ -48,5 +48,14 @@ func (b Bitvector4) Count() uint64 {
 	if len(b) == 0 {
 		return 0
 	}
-	return uint64(bits.OnesCount8(b[0] & 0x0F))
+	return uint64(bits.OnesCount8(b.Bytes()[0]))
+}
+
+// Bytes returns the bytes data representing the bitvector4. This method
+// bitmasks the underlying data to unsure that it is an accurate representation.
+func (b Bitvector4) Bytes() []byte {
+	if len(b) == 0 {
+		return []byte{}
+	}
+	return []byte{b[0] & 0x0F}
 }

--- a/bitvector_test.go
+++ b/bitvector_test.go
@@ -202,3 +202,50 @@ func TestBitvector4_Count(t *testing.T) {
 		}
 	}
 }
+
+func TestBitvector4_Bytes(t *testing.T) {
+	tests := []struct {
+		bitvector Bitvector4
+		want      []byte
+	}{
+		{
+			bitvector: Bitvector4{},
+			want:      []byte{},
+		},
+		{
+			bitvector: Bitvector4{0x01}, // 0b00000001
+			want:      []byte{0x01},     // 0b00000001
+		},
+		{
+			bitvector: Bitvector4{0x03}, // 0b00000011
+			want:      []byte{0x03},     // 0b00000011
+		},
+		{
+			bitvector: Bitvector4{0x07}, // 0b00000111
+			want:      []byte{0x07},     // 0b00000111
+		},
+		{
+			bitvector: Bitvector4{0x0F}, // 0b00001111
+			want:      []byte{0x0F},     // 0b00001111
+		},
+		{
+			bitvector: Bitvector4{0xFF}, // 0b11111111
+			want:      []byte{0x0F},     // 0b00000001
+		},
+		{
+			bitvector: Bitvector4{0xF0}, // 0b11110000
+			want:      []byte{0x00},     // 0b00000000
+		},
+	}
+
+	for _, tt := range tests {
+		if !bytes.Equal(tt.bitvector.Bytes(), tt.want) {
+			t.Errorf(
+				"(%x).Bytes() = %x, wanted %x",
+				tt.bitvector,
+				tt.bitvector.Bytes(),
+				tt.want,
+			)
+		}
+	}
+}

--- a/bitvector_test.go
+++ b/bitvector_test.go
@@ -213,6 +213,10 @@ func TestBitvector4_Bytes(t *testing.T) {
 			want:      []byte{},
 		},
 		{
+			bitvector: Bitvector4{0x00}, // 0b00000000
+			want:      []byte{0x00},     // 0b00000000
+		},
+		{
 			bitvector: Bitvector4{0x01}, // 0b00000001
 			want:      []byte{0x01},     // 0b00000001
 		},


### PR DESCRIPTION
This ensures that bitvectors can produce accurate representation of their underlying data. 