### PR TITLE
Fix panic condition on bytes for bitlist

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -83,6 +83,10 @@ func (b Bitlist) Len() uint64 {
 // representation of the bitlist. This may produce an empty byte slice if all
 // bits were zero.
 func (b Bitlist) Bytes() []byte {
+	if len(b) == 0 {
+		return []byte{}
+	}
+
 	ret := make([]byte, len(b))
 	copy(ret, b)
 

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -296,6 +296,10 @@ func TestBitlist_Bytes(t *testing.T) {
 		want    []byte
 	}{
 		{
+			bitlist: Bitlist{},
+			want:    []byte{},
+		},
+		{
 			bitlist: Bitlist{0x01},
 			want:    []byte{},
 		},


### PR DESCRIPTION
There was a failure condition when calling Bytes() on a bitlist with no bytes.