### PR TITLE
Byte empty check

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -150,6 +150,10 @@ func (b Bitlist) Overlaps(c Bitlist) bool {
 
 	bytes1 := b.Bytes()
 	bytes2 := c.Bytes()
+	if len(bytes1) == 0 || len(bytes2) == 0 {
+		panic("bitlists can not be empty")
+	}
+
 	// To ensure all of the bits in c are not overlapped in b, we iterate over every byte, invert b
 	// and xor the byte from b and c, then and it against c. If the result is non-zero, then
 	// we can be assured that byte in c had bits not overlapped in b.

--- a/bitlist.go
+++ b/bitlist.go
@@ -151,7 +151,7 @@ func (b Bitlist) Overlaps(c Bitlist) bool {
 	bytes1 := b.Bytes()
 	bytes2 := c.Bytes()
 	if len(bytes1) == 0 || len(bytes2) == 0 {
-		panic("bitlists can not be empty")
+		return false
 	}
 
 	// To ensure all of the bits in c are not overlapped in b, we iterate over every byte, invert b

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -484,6 +484,11 @@ func TestBitlist_Overlaps(t *testing.T) {
 			want: false,
 		},
 		{
+			a:    Bitlist{0x41}, // 0b00100001
+			b:    Bitlist{0x40}, // 0b00100000
+			want: false,
+		},
+		{
 			a:    Bitlist{0x1F}, // 0b00011111
 			b:    Bitlist{0x11}, // 0b00010001
 			want: true,


### PR DESCRIPTION
This PR adds in an additional check to make sure the byte can't be empty. I saw this happened during run time and panic