### PR TITLE
Determine overlap without copy and fix panic

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -148,17 +148,24 @@ func (b Bitlist) Overlaps(c Bitlist) bool {
 		panic("bitlists are different lengths")
 	}
 
-	bytes1 := b.Bytes()
-	bytes2 := c.Bytes()
-	if len(bytes1) == 0 || len(bytes2) == 0 {
+	if b.Len() == 0 || b.Len() == 0 {
 		return false
 	}
+
+	msb := uint8(bits.Len8(b[len(b)-1])) - 1
+	lengthBitMask := uint8(1 << msb)
 
 	// To ensure all of the bits in c are not overlapped in b, we iterate over every byte, invert b
 	// and xor the byte from b and c, then and it against c. If the result is non-zero, then
 	// we can be assured that byte in c had bits not overlapped in b.
-	for i := 0; i < len(bytes1); i++ {
-		if (^bytes1[i]^bytes2[i])&bytes2[i] != 0 {
+	for i := 0; i < len(b); i++ {
+		// If this byte is the last byte in the array, mask the length bit.
+		mask := uint8(0xFF)
+		if i == len(b)-1 {
+			mask &^= lengthBitMask
+		}
+
+		if (^b[i]^c[i])&c[i]&mask != 0 {
 			return true
 		}
 	}

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -518,6 +518,11 @@ func TestBitlist_Overlaps(t *testing.T) {
 			b:    Bitlist{0x03, 0x40}, // 0b00000011, 0b01000000
 			want: true,
 		},
+		{
+			a:    Bitlist{0x01, 0x01, 0x01}, // 0b00000001, 0b00000001, 0b00000001
+			b:    Bitlist{0x02, 0x00, 0x01}, // 0b00000010, 0b00000000, 0b00000001
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`Bytes()` was showing up often on my profile in prysm. This copy is unnecessary as we can read the underlying array and ignore the length bit. Additionally, `Bytes()` would strip any leading zeros from the returned slice so you could incur a panic. 