### PR TITLE
Fix zero case contains

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -125,8 +125,13 @@ func (b Bitlist) Count() uint64 {
 // Contains returns true if the bitlist contains all of the bits from the provided argument
 // bitlist. This method will panic if bitlists are not the same length.
 func (b Bitlist) Contains(c Bitlist) bool {
-	if b.Len() != c.Len() {
+	lenB := b.Len()
+	if lenB != c.Len() {
 		panic("bitlists are different lengths")
+	}
+
+	if lenB == 0 {
+		return false
 	}
 
 	// To ensure all of the bits in c are present in b, we iterate over every byte, combine

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -452,6 +452,11 @@ func TestBitlist_Contains(t *testing.T) {
 			b:    Bitlist{0x13, 0x83}, // 0b00010011, 0x10000011
 			want: true,
 		},
+		{
+			a:    NewBitlist(0),
+			b:    NewBitlist(0),
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This would return true when both lists were zero bits, which is not accurate.