### PR TITLE
Adds bitlist.And/Xor/Not methods

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -187,6 +187,20 @@ func (b Bitlist) Or(c Bitlist) Bitlist {
 	return ret
 }
 
+// And returns the AND result of the two bitfields. This method will panic if the bitlists are not the same length.
+func (b Bitlist) And(c Bitlist) Bitlist {
+	if b.Len() != c.Len() {
+		panic("bitlists are different lengths")
+	}
+
+	ret := make([]byte, len(b))
+	for i := 0; i < len(b); i++ {
+		ret[i] = b[i] & c[i]
+	}
+
+	return ret
+}
+
 func (b Bitlist) BitIndices() []int {
 	indices := make([]int, 0, b.Count())
 	for i, bt := range b {

--- a/bitlist.go
+++ b/bitlist.go
@@ -201,6 +201,30 @@ func (b Bitlist) And(c Bitlist) Bitlist {
 	return ret
 }
 
+// Xor returns the XOR result of the two bitfields. This method will panic if the bitlists are not the same length.
+func (b Bitlist) Xor(c Bitlist) Bitlist {
+	if b.Len() != c.Len() {
+		panic("bitlists are different lengths")
+	}
+
+	ret := make([]byte, len(b))
+	for i := 0; i < len(b); i++ {
+		ret[i] = b[i] ^ c[i]
+	}
+
+	return ret
+}
+
+// Not returns the NOT result of the bitfield.
+func (b Bitlist) Not() Bitlist {
+	ret := make([]byte, len(b))
+	for i := 0; i < len(b); i++ {
+		ret[i] = ^b[i]
+	}
+
+	return ret
+}
+
 func (b Bitlist) BitIndices() []int {
 	indices := make([]int, 0, b.Count())
 	for i, bt := range b {

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -662,6 +662,118 @@ func TestBitlist_And(t *testing.T) {
 	}
 }
 
+func TestBitlist_Xor(t *testing.T) {
+	tests := []struct {
+		a    Bitlist
+		b    Bitlist
+		want Bitlist
+	}{
+		{
+			a:    Bitlist{0x02}, // 0b00000010
+			b:    Bitlist{0x03}, // 0b00000011
+			want: Bitlist{0x01}, // 0b00000001
+		},
+		{
+			a:    Bitlist{0x03}, // 0b00000011
+			b:    Bitlist{0x03}, // 0b00000011
+			want: Bitlist{0x00}, // 0b00000000
+		},
+		{
+			a:    Bitlist{0x13}, // 0b00010011
+			b:    Bitlist{0x15}, // 0b00010101
+			want: Bitlist{0x06}, // 0b00000110
+		},
+		{
+			a:    Bitlist{0x1F}, // 0b00011111
+			b:    Bitlist{0x13}, // 0b00010011
+			want: Bitlist{0x0c}, // 0b00001100
+		},
+		{
+			a:    Bitlist{0x1F, 0x03}, // 0b00011111, 0b00000011
+			b:    Bitlist{0x13, 0x02}, // 0b00010011, 0b00000010
+			want: Bitlist{0x0c, 0x01}, // 0b00001100, 0b00000001
+		},
+		{
+			a:    Bitlist{0x9F, 0x01}, // 0b10011111, 0b00000001
+			b:    Bitlist{0x93, 0x01}, // 0b10010011, 0b00000001
+			want: Bitlist{0x0c, 0x00}, // 0b00001100, 0b00000000
+		},
+		{
+			a:    Bitlist{0xFF, 0x02}, // 0b11111111, 0x00000010
+			b:    Bitlist{0x13, 0x03}, // 0b00010011, 0x00000011
+			want: Bitlist{0xec, 0x01}, // 0b11101100, 0x00000001
+		},
+		{
+			a:    Bitlist{0xFF, 0x87}, // 0b11111111, 0x10000111
+			b:    Bitlist{0x13, 0x8F}, // 0b00010011, 0x10001111
+			want: Bitlist{0xec, 0x08}, // 0b11101100, 0x00001000
+		},
+	}
+
+	for _, tt := range tests {
+		if !bytes.Equal(tt.a.Xor(tt.b), tt.want) {
+			t.Errorf(
+				"(%x).Xor(%x) = %x, wanted %x",
+				tt.a,
+				tt.b,
+				tt.a.Xor(tt.b),
+				tt.want,
+			)
+		}
+	}
+}
+
+func TestBitlist_Not(t *testing.T) {
+	tests := []struct {
+		a    Bitlist
+		want Bitlist
+	}{
+		{
+			a:    Bitlist{0x02}, // 0b00000010
+			want: Bitlist{0xfd}, // 0b11111101
+		},
+		{
+			a:    Bitlist{0x83}, // 0b10000011
+			want: Bitlist{0x7c}, // 0b01111100
+		},
+		{
+			a:    Bitlist{0x13}, // 0b00010011
+			want: Bitlist{0xec}, // 0b11101100
+		},
+		{
+			a:    Bitlist{0x1F}, // 0b00011111
+			want: Bitlist{0xe0}, // 0b11100000
+		},
+		{
+			a:    Bitlist{0x1F, 0x03}, // 0b00011111, 0b00000011
+			want: Bitlist{0xe0, 0xfc}, // 0b11100000, 0b11111100
+		},
+		{
+			a:    Bitlist{0x9F, 0x01}, // 0b10011111, 0b00000001
+			want: Bitlist{0x60, 0xfe}, // 0b01100000, 0b11111110
+		},
+		{
+			a:    Bitlist{0xFF, 0x02}, // 0b11111111, 0x00000010
+			want: Bitlist{0x00, 0xfd}, // 0b00000000, 0x11111101
+		},
+		{
+			a:    Bitlist{0xFF, 0x87}, // 0b11111111, 0x10000111
+			want: Bitlist{0x00, 0x78}, // 0b00000000, 0x01111000
+		},
+	}
+
+	for _, tt := range tests {
+		if !bytes.Equal(tt.a.Not(), tt.want) {
+			t.Errorf(
+				"(%x).Not() = %x, wanted %x",
+				tt.a,
+				tt.a.Not(),
+				tt.want,
+			)
+		}
+	}
+}
+
 func TestBitlist_BitIndices(t *testing.T) {
 	tests := []struct {
 		a    Bitlist

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -2,8 +2,8 @@ package bitfield
 
 import (
 	"bytes"
-	"testing"
 	"reflect"
+	"testing"
 )
 
 func TestNewBitlist(t *testing.T) {
@@ -601,25 +601,86 @@ func TestBitlist_Or(t *testing.T) {
 	}
 }
 
+func TestBitlist_And(t *testing.T) {
+	tests := []struct {
+		a    Bitlist
+		b    Bitlist
+		want Bitlist
+	}{
+		{
+			a:    Bitlist{0x02}, // 0b00000010
+			b:    Bitlist{0x03}, // 0b00000011
+			want: Bitlist{0x02}, // 0b00000010
+		},
+		{
+			a:    Bitlist{0x03}, // 0b00000011
+			b:    Bitlist{0x03}, // 0b00000011
+			want: Bitlist{0x03}, // 0b00000011
+		},
+		{
+			a:    Bitlist{0x13}, // 0b00010011
+			b:    Bitlist{0x15}, // 0b00010101
+			want: Bitlist{0x11}, // 0b00010001
+		},
+		{
+			a:    Bitlist{0x1F}, // 0b00011111
+			b:    Bitlist{0x13}, // 0b00010011
+			want: Bitlist{0x13}, // 0b00010011
+		},
+		{
+			a:    Bitlist{0x1F, 0x03}, // 0b00011111, 0b00000011
+			b:    Bitlist{0x13, 0x02}, // 0b00010011, 0b00000010
+			want: Bitlist{0x13, 0x02}, // 0b00010011, 0b00000010
+		},
+		{
+			a:    Bitlist{0x9F, 0x01}, // 0b10011111, 0b00000001
+			b:    Bitlist{0x93, 0x01}, // 0b10010011, 0b00000001
+			want: Bitlist{0x93, 0x01}, // 0b10010011, 0b00000001
+		},
+		{
+			a:    Bitlist{0xFF, 0x02}, // 0b11111111, 0x00000010
+			b:    Bitlist{0x13, 0x03}, // 0b00010011, 0x00000011
+			want: Bitlist{0x13, 0x02}, // 0b00010011, 0x00000010
+		},
+		{
+			a:    Bitlist{0xFF, 0x87}, // 0b11111111, 0x10000111
+			b:    Bitlist{0x13, 0x8F}, // 0b00010011, 0x10001111
+			want: Bitlist{0x13, 0x87}, // 0b00010011, 0x10000111
+		},
+	}
+
+	for _, tt := range tests {
+		if !bytes.Equal(tt.a.And(tt.b), tt.want) {
+			t.Errorf(
+				"(%x).And(%x) = %x, wanted %x",
+				tt.a,
+				tt.b,
+				tt.a.And(tt.b),
+				tt.want,
+			)
+		}
+	}
+}
+
 func TestBitlist_BitIndices(t *testing.T) {
 	tests := []struct {
 		a    Bitlist
 		want []int
 	}{
 		{
-			a: Bitlist{0b10010},
+			a:    Bitlist{0b10010},
 			want: []int{1},
 		},
 		{
-			a: Bitlist{0b10000},
+			a:    Bitlist{0b10000},
 			want: []int{},
 		},
 		{
-			a: Bitlist{0b10, 0b1},
+			a:    Bitlist{0b10, 0b1},
 			want: []int{1},
 		},
 		{
-			a: Bitlist{0b11111111, 0b11},
+			a:    Bitlist{0b11111111, 0b11},
 			want: []int{0, 1, 2, 3, 4, 5, 6, 7, 8},
 		},
 	}


### PR DESCRIPTION
- Adds `bitlist.And`, `bitlist.Xor`, and `bitlist.Not` methods (needed for bitlist manipulation in max_cover att aggregation)