### PR TITLE
Fixes issue with MSB in Not() and Xor()

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -217,9 +217,23 @@ func (b Bitlist) Xor(c Bitlist) Bitlist {
 
 // Not returns the NOT result of the bitfield.
 func (b Bitlist) Not() Bitlist {
+	if b.Len() == 0 {
+		return b
+	}
 	ret := make([]byte, len(b))
-	for i := 0; i < len(b); i++ {
+
+	// Process all bytes but the last.
+	for i := 0; i < len(b)-1; i++ {
 		ret[i] = ^b[i]
+	}
+
+	// For the last byte, process only bits smaller than the length bit.
+	ret[len(b)-1] = b[len(b)-1]
+	msb := uint8(bits.Len8(b[len(b)-1])) - 1
+	if msb > 0 {
+		mask := ^uint8(0xff >> (8 - msb))
+		ret[len(b)-1] = ^(b[len(b)-1]) ^ mask
+		ret[len(b)-1] |= uint8(1 << msb)
 	}
 
 	return ret

--- a/bitlist.go
+++ b/bitlist.go
@@ -207,9 +207,19 @@ func (b Bitlist) Xor(c Bitlist) Bitlist {
 		panic("bitlists are different lengths")
 	}
 
+	// Process all bytes but the last.
 	ret := make([]byte, len(b))
-	for i := 0; i < len(b); i++ {
+	for i := 0; i < len(b)-1; i++ {
 		ret[i] = b[i] ^ c[i]
+	}
+
+	// For the last byte, process only bits smaller than the length bit.
+	ret[len(b)-1] = b[len(b)-1]
+	msb := uint8(bits.Len8(b[len(b)-1])) - 1
+	if msb > 0 {
+		mask := uint8(0xff >> (8 - msb))
+		ret[len(b)-1] = (b[len(b)-1] ^ c[len(b)-1]) & mask
+		ret[len(b)-1] |= uint8(1 << msb)
 	}
 
 	return ret
@@ -220,9 +230,9 @@ func (b Bitlist) Not() Bitlist {
 	if b.Len() == 0 {
 		return b
 	}
-	ret := make([]byte, len(b))
 
 	// Process all bytes but the last.
+	ret := make([]byte, len(b))
 	for i := 0; i < len(b)-1; i++ {
 		ret[i] = ^b[i]
 	}
@@ -231,8 +241,8 @@ func (b Bitlist) Not() Bitlist {
 	ret[len(b)-1] = b[len(b)-1]
 	msb := uint8(bits.Len8(b[len(b)-1])) - 1
 	if msb > 0 {
-		mask := ^uint8(0xff >> (8 - msb))
-		ret[len(b)-1] = ^(b[len(b)-1]) ^ mask
+		mask := uint8(0xff >> (8 - msb))
+		ret[len(b)-1] = (^b[len(b)-1]) & mask
 		ret[len(b)-1] |= uint8(1 << msb)
 	}
 

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -672,55 +672,57 @@ func TestBitlist_Xor(t *testing.T) {
 		{
 			a:    Bitlist{0x02}, // 0b00000010
 			b:    Bitlist{0x03}, // 0b00000011
-			want: Bitlist{0x01}, // 0b00000001
+			want: Bitlist{0x03}, // 0b00000011
 		},
 		{
 			a:    Bitlist{0x03}, // 0b00000011
 			b:    Bitlist{0x03}, // 0b00000011
-			want: Bitlist{0x00}, // 0b00000000
+			want: Bitlist{0x02}, // 0b00000010
 		},
 		{
 			a:    Bitlist{0x13}, // 0b00010011
 			b:    Bitlist{0x15}, // 0b00010101
-			want: Bitlist{0x06}, // 0b00000110
+			want: Bitlist{0x16}, // 0b00010110
 		},
 		{
 			a:    Bitlist{0x1F}, // 0b00011111
 			b:    Bitlist{0x13}, // 0b00010011
-			want: Bitlist{0x0c}, // 0b00001100
+			want: Bitlist{0x1c}, // 0b00011100
 		},
 		{
 			a:    Bitlist{0x1F, 0x03}, // 0b00011111, 0b00000011
 			b:    Bitlist{0x13, 0x02}, // 0b00010011, 0b00000010
-			want: Bitlist{0x0c, 0x01}, // 0b00001100, 0b00000001
+			want: Bitlist{0x0c, 0x03}, // 0b00001100, 0b00000011
 		},
 		{
 			a:    Bitlist{0x9F, 0x01}, // 0b10011111, 0b00000001
 			b:    Bitlist{0x93, 0x01}, // 0b10010011, 0b00000001
-			want: Bitlist{0x0c, 0x00}, // 0b00001100, 0b00000000
+			want: Bitlist{0x0c, 0x01}, // 0b00001100, 0b00000001
 		},
 		{
 			a:    Bitlist{0xFF, 0x02}, // 0b11111111, 0x00000010
 			b:    Bitlist{0x13, 0x03}, // 0b00010011, 0x00000011
-			want: Bitlist{0xec, 0x01}, // 0b11101100, 0x00000001
+			want: Bitlist{0xec, 0x03}, // 0b11101100, 0x00000011
 		},
 		{
 			a:    Bitlist{0xFF, 0x87}, // 0b11111111, 0x10000111
 			b:    Bitlist{0x13, 0x8F}, // 0b00010011, 0x10001111
-			want: Bitlist{0xec, 0x08}, // 0b11101100, 0x00001000
+			want: Bitlist{0xec, 0x88}, // 0b11101100, 0x10001000
 		},
 	}
 
 	for _, tt := range tests {
-		if !bytes.Equal(tt.a.Xor(tt.b), tt.want) {
-			t.Errorf(
-				"(%x).Xor(%x) = %x, wanted %x",
-				tt.a,
-				tt.b,
-				tt.a.Xor(tt.b),
-				tt.want,
-			)
-		}
+		t.Run(fmt.Sprintf("(%x).Xor(%x)", tt.a, tt.b), func(t *testing.T) {
+			if !bytes.Equal(tt.a.Xor(tt.b), tt.want) {
+				t.Errorf(
+					"(%x).Xor(%x) = %x, wanted %x",
+					tt.a,
+					tt.b,
+					tt.a.Xor(tt.b),
+					tt.want,
+				)
+			}
+		})
 	}
 }
 

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -2,6 +2,7 @@ package bitfield
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -729,48 +730,70 @@ func TestBitlist_Not(t *testing.T) {
 		want Bitlist
 	}{
 		{
+			a:    Bitlist{0x01}, // 0b00000001
+			want: Bitlist{0x01}, // 0b00000001
+		},
+		{
 			a:    Bitlist{0x02}, // 0b00000010
-			want: Bitlist{0xfd}, // 0b11111101
+			want: Bitlist{0x03}, // 0b00000011
+		},
+		{
+			a:    Bitlist{0x03}, // 0b00000011
+			want: Bitlist{0x02}, // 0b00000010
+		},
+		{
+			a:    Bitlist{0x05}, // 0b00000101
+			want: Bitlist{0x06}, // 0b00000110
+		},
+		{
+			a:    Bitlist{0x06}, // 0b00000110
+			want: Bitlist{0x05}, // 0b00000101
 		},
 		{
 			a:    Bitlist{0x83}, // 0b10000011
-			want: Bitlist{0x7c}, // 0b01111100
+			want: Bitlist{0xfc}, // 0b11111100
 		},
 		{
 			a:    Bitlist{0x13}, // 0b00010011
-			want: Bitlist{0xec}, // 0b11101100
+			want: Bitlist{0x1c}, // 0b00011100
 		},
 		{
 			a:    Bitlist{0x1F}, // 0b00011111
-			want: Bitlist{0xe0}, // 0b11100000
+			want: Bitlist{0x10}, // 0b00010000
 		},
 		{
 			a:    Bitlist{0x1F, 0x03}, // 0b00011111, 0b00000011
-			want: Bitlist{0xe0, 0xfc}, // 0b11100000, 0b11111100
+			want: Bitlist{0xe0, 0x02}, // 0b11100000, 0b00000010
 		},
 		{
 			a:    Bitlist{0x9F, 0x01}, // 0b10011111, 0b00000001
-			want: Bitlist{0x60, 0xfe}, // 0b01100000, 0b11111110
+			want: Bitlist{0x60, 0x01}, // 0b01100000, 0b00000001
 		},
 		{
 			a:    Bitlist{0xFF, 0x02}, // 0b11111111, 0x00000010
-			want: Bitlist{0x00, 0xfd}, // 0b00000000, 0x11111101
+			want: Bitlist{0x00, 0x03}, // 0b00000000, 0x00000011
 		},
 		{
 			a:    Bitlist{0xFF, 0x87}, // 0b11111111, 0x10000111
-			want: Bitlist{0x00, 0x78}, // 0b00000000, 0x01111000
+			want: Bitlist{0x00, 0xf8}, // 0b00000000, 0x11111000
+		},
+		{
+			a:    Bitlist{0xFF, 0x07}, // 0b11111111, 0x00000111
+			want: Bitlist{0x00, 0x04}, // 0b00000000, 0x00000100
 		},
 	}
 
 	for _, tt := range tests {
-		if !bytes.Equal(tt.a.Not(), tt.want) {
-			t.Errorf(
-				"(%x).Not() = %x, wanted %x",
-				tt.a,
-				tt.a.Not(),
-				tt.want,
-			)
-		}
+		t.Run(fmt.Sprintf("(%#x).Not()", tt.a), func(t *testing.T) {
+			if !bytes.Equal(tt.a.Not(), tt.want) {
+				t.Errorf(
+					"(%x).Not() = %x, wanted %x",
+					tt.a,
+					tt.a.Not(),
+					tt.want,
+				)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
- For the `bitfield.Or()` and `bitfield.And()` the value of MSB wasn't important (we are working with bitfields of the same size - so the last byte has MSB set at the same position, making zero bits after MSB not affecting the final solution i.e. `0 | 0 = 0` and `0 & 0 = 0`).
- With `bitfield.Not()` we need to take MSB into account and not update bits higher than MSB (which is used as delimiter - no bits after it should be considered part of the bitfield).
- The same story for `bitlist.Xor()` (it has also been updated).