### PR TITLE
Fix overflow in Len(), on invalid bitlist

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -71,6 +71,9 @@ func (b Bitlist) Len() uint64 {
 
 	// Determine the position of the most significant bit.
 	msb := bits.Len8(last)
+	if msb == 0 {
+		return 0
+	}
 
 	// The absolute position of the most significant bit will be the number of
 	// bits in the preceding bytes plus the position of the most significant

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -61,6 +61,10 @@ func TestBitlist_Len(t *testing.T) {
 			want:    0,
 		},
 		{
+			bitlist: Bitlist{0x00}, // 0b00000000, invalid list
+			want:    0,
+		},
+		{
 			bitlist: Bitlist{0x01}, // 0b00000001
 			want:    0,
 		},
@@ -302,6 +306,10 @@ func TestBitlist_Bytes(t *testing.T) {
 			want:    []byte{},
 		},
 		{
+			bitlist: Bitlist{0x00},
+			want:    []byte{},
+		},
+		{
 			bitlist: Bitlist{0x01},
 			want:    []byte{},
 		},
@@ -362,6 +370,10 @@ func TestBitlist_Count(t *testing.T) {
 	}{
 		{
 			bitlist: Bitlist{},
+			want:    0,
+		},
+		{
+			bitlist: Bitlist{0x00}, // 0b00000000, invalid list
 			want:    0,
 		},
 		{


### PR DESCRIPTION
- Resolves overflow discovered by @nisdas 

```golang
func TestBadBitlist(t *testing.T) {
    list := bitfield.Bitlist{0x00}
    receivedLen := list.Len()
    t.Error(receivedLen)
}

result: 18446744073709551615
```