### PR TITLE
Implement AndCount(), OrCount(), XorCount()

### DIFF
--- a/bitlist64.go
+++ b/bitlist64.go
@@ -202,6 +202,21 @@ func (b *Bitlist64) And(c *Bitlist64) *Bitlist64 {
 	return ret
 }
 
+// AndCount calculates number of bits set to true in and intersection of two bitfields.
+// This method will panic if the bitlists are not the same length.
+func (b *Bitlist64) AndCount(c *Bitlist64) uint64 {
+	if b.Len() != c.Len() {
+		panic("bitlists are different lengths")
+	}
+
+	var cnt int
+	for idx := range b.data {
+		cnt += bits.OnesCount64(b.data[idx] & c.data[idx])
+	}
+
+	return uint64(cnt)
+}
+
 // NoAllocAnd computes the AND result of the two bitfields (intersection).
 // Result is written into provided variable, so no allocation takes place inside the function.
 // This method will panic if the bitlists are not the same length.

--- a/bitlist64.go
+++ b/bitlist64.go
@@ -189,6 +189,21 @@ func (b *Bitlist64) NoAllocOr(c, ret *Bitlist64) {
 	}
 }
 
+// OrCount calculates number of bits set in a union of two bitfields.
+// This method will panic if the bitlists are not the same length.
+func (b *Bitlist64) OrCount(c *Bitlist64) uint64 {
+	if b.Len() != c.Len() {
+		panic("bitlists are different lengths")
+	}
+
+	var cnt int
+	for idx := range b.data {
+		cnt += bits.OnesCount64(b.data[idx] | c.data[idx])
+	}
+
+	return uint64(cnt)
+}
+
 // And returns the AND result of the two bitfields (intersection).
 // This method will panic if the bitlists are not the same length.
 func (b *Bitlist64) And(c *Bitlist64) *Bitlist64 {
@@ -202,7 +217,7 @@ func (b *Bitlist64) And(c *Bitlist64) *Bitlist64 {
 	return ret
 }
 
-// AndCount calculates number of bits set to true in and intersection of two bitfields.
+// AndCount calculates number of bits set in an intersection of two bitfields.
 // This method will panic if the bitlists are not the same length.
 func (b *Bitlist64) AndCount(c *Bitlist64) uint64 {
 	if b.Len() != c.Len() {

--- a/bitlist64.go
+++ b/bitlist64.go
@@ -271,6 +271,21 @@ func (b *Bitlist64) NoAllocXor(c, ret *Bitlist64) {
 	}
 }
 
+// XorCount calculates number of bits set in a symmetric difference of two bitfields.
+// This method will panic if the bitlists are not the same length.
+func (b *Bitlist64) XorCount(c *Bitlist64) uint64 {
+	if b.Len() != c.Len() {
+		panic("bitlists are different lengths")
+	}
+
+	var cnt int
+	for idx := range b.data {
+		cnt += bits.OnesCount64(b.data[idx] ^ c.data[idx])
+	}
+
+	return uint64(cnt)
+}
+
 // Not returns the NOT result of the bitfield (complement).
 func (b *Bitlist64) Not() *Bitlist64 {
 	if b.Len() == 0 {

--- a/bitlist64_test.go
+++ b/bitlist64_test.go
@@ -1133,6 +1133,13 @@ func TestBitlist64_Xor(t *testing.T) {
 			}
 		}
 	})
+	t.Run("XorCount()", func(t *testing.T) {
+		for _, tt := range tests {
+			if tt.a.XorCount(tt.b) != tt.want.Count() {
+				t.Errorf("(%+v).XorCount(%+v) = %d, wanted %d", tt.a, tt.b, tt.a.XorCount(tt.b), tt.want.Count())
+			}
+		}
+	})
 	t.Run("check panics", func(t *testing.T) {
 		t.Run("Xor()", func(t *testing.T) {
 			defer func() {
@@ -1165,6 +1172,16 @@ func TestBitlist64_Xor(t *testing.T) {
 			b := NewBitlist64(64)
 			ret := NewBitlist64(128)
 			a.NoAllocXor(b, ret)
+		})
+		t.Run("XorCount()", func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("Expected panic not thrown")
+				}
+			}()
+			a := NewBitlist64(64)
+			b := NewBitlist64(128)
+			a.XorCount(b)
 		})
 	})
 }

--- a/bitlist64_test.go
+++ b/bitlist64_test.go
@@ -989,6 +989,13 @@ func TestBitlist64_And(t *testing.T) {
 			}
 		}
 	})
+	t.Run("AndCount()", func(t *testing.T) {
+		for _, tt := range tests {
+			if tt.a.AndCount(tt.b) != tt.want.Count() {
+				t.Errorf("(%+v).AndCount(%+v) = %d, wanted %d", tt.a, tt.b, tt.a.AndCount(tt.b), tt.want.Count())
+			}
+		}
+	})
 	t.Run("check panics", func(t *testing.T) {
 		t.Run("And()", func(t *testing.T) {
 			defer func() {
@@ -1021,6 +1028,16 @@ func TestBitlist64_And(t *testing.T) {
 			b := NewBitlist64(64)
 			ret := NewBitlist64(128)
 			a.NoAllocAnd(b, ret)
+		})
+		t.Run("AndCount()", func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("Expected panic not thrown")
+				}
+			}()
+			a := NewBitlist64(64)
+			b := NewBitlist64(128)
+			a.AndCount(b)
 		})
 	})
 }

--- a/bitlist64_test.go
+++ b/bitlist64_test.go
@@ -884,6 +884,13 @@ func TestBitlist64_Or(t *testing.T) {
 			}
 		}
 	})
+	t.Run("OrCount()", func(t *testing.T) {
+		for _, tt := range tests {
+			if tt.a.OrCount(tt.b) != tt.want.Count() {
+				t.Errorf("(%+v).OrCount(%+v) = %d, wanted %d", tt.a, tt.b, tt.a.OrCount(tt.b), tt.want.Count())
+			}
+		}
+	})
 	t.Run("check panics", func(t *testing.T) {
 		t.Run("Or()", func(t *testing.T) {
 			defer func() {
@@ -916,6 +923,16 @@ func TestBitlist64_Or(t *testing.T) {
 			b := NewBitlist64(64)
 			ret := NewBitlist64(128)
 			a.NoAllocOr(b, ret)
+		})
+		t.Run("OrCount()", func(t *testing.T) {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Error("Expected panic not thrown")
+				}
+			}()
+			a := NewBitlist64(64)
+			b := NewBitlist64(128)
+			a.OrCount(b)
 		})
 	})
 }

--- a/bitlist_bench_test.go
+++ b/bitlist_bench_test.go
@@ -378,6 +378,80 @@ func BenchmarkBitlist_And(b *testing.B) {
 	}
 }
 
+func BenchmarkBitlist_AndCount(b *testing.B) {
+	for n := uint64(0); n <= 2048; n += 256 {
+		b.Run(fmt.Sprintf("size:%d", n), func(b *testing.B) {
+			b.Run("[]byte", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist(n)
+				s1 := NewBitlist(n) // has overlaps
+				s2 := NewBitlist(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.And(s1).Count()
+					s.And(s2).Count()
+				}
+			})
+			b.Run("[]uint64", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.And(s1).Count()
+					s.And(s2).Count()
+				}
+			})
+			b.Run("[]uint64 (noalloc)", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				result := s.Clone()
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.NoAllocAnd(s1, result)
+					result.Count()
+					s.NoAllocAnd(s2, result)
+					result.Count()
+				}
+			})
+			b.Run("[]uint64 (AndCount)", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.AndCount(s1)
+					s.AndCount(s2)
+				}
+			})
+		})
+	}
+}
+
 func BenchmarkBitlist_Xor(b *testing.B) {
 	for n := uint64(0); n <= 2048; n += 256 {
 		b.Run(fmt.Sprintf("size:%d", n), func(b *testing.B) {

--- a/bitlist_bench_test.go
+++ b/bitlist_bench_test.go
@@ -582,6 +582,80 @@ func BenchmarkBitlist_Xor(b *testing.B) {
 	}
 }
 
+func BenchmarkBitlist_XorCount(b *testing.B) {
+	for n := uint64(0); n <= 2048; n += 256 {
+		b.Run(fmt.Sprintf("size:%d", n), func(b *testing.B) {
+			b.Run("[]byte", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist(n)
+				s1 := NewBitlist(n) // has overlaps
+				s2 := NewBitlist(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.Xor(s1).Count()
+					s.Xor(s2).Count()
+				}
+			})
+			b.Run("[]uint64", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.Xor(s1).Count()
+					s.Xor(s2).Count()
+				}
+			})
+			b.Run("[]uint64 (noalloc)", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				result := s.Clone()
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.NoAllocXor(s1, result)
+					result.Count()
+					s.NoAllocXor(s2, result)
+					result.Count()
+				}
+			})
+			b.Run("[]uint64 (XorCount)", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.XorCount(s1)
+					s.XorCount(s2)
+				}
+			})
+		})
+	}
+}
+
 func BenchmarkBitlist_Not(b *testing.B) {
 	for n := uint64(0); n <= 2048; n += 256 {
 		b.Run(fmt.Sprintf("size:%d", n), func(b *testing.B) {

--- a/bitlist_bench_test.go
+++ b/bitlist_bench_test.go
@@ -322,6 +322,80 @@ func BenchmarkBitlist_Or(b *testing.B) {
 	}
 }
 
+func BenchmarkBitlist_OrCount(b *testing.B) {
+	for n := uint64(0); n <= 2048; n += 256 {
+		b.Run(fmt.Sprintf("size:%d", n), func(b *testing.B) {
+			b.Run("[]byte", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist(n)
+				s1 := NewBitlist(n) // has overlaps
+				s2 := NewBitlist(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.Or(s1).Count()
+					s.Or(s2).Count()
+				}
+			})
+			b.Run("[]uint64", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.Or(s1).Count()
+					s.Or(s2).Count()
+				}
+			})
+			b.Run("[]uint64 (noalloc)", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				result := s.Clone()
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.NoAllocOr(s1, result)
+					result.Count()
+					s.NoAllocOr(s2, result)
+					result.Count()
+				}
+			})
+			b.Run("[]uint64 (OrCount)", func(b *testing.B) {
+				b.StopTimer()
+				s := NewBitlist64(n)
+				s1 := NewBitlist64(n) // has overlaps
+				s2 := NewBitlist64(n) // no overlaps
+				for i := uint64(0); i < n; i += 100 {
+					s.SetBitAt(i, true)
+					s1.SetBitAt(i, true)
+					s2.SetBitAt(i+1, true)
+				}
+				b.StartTimer()
+				for i := 0; i < b.N; i++ {
+					s.OrCount(s1)
+					s.OrCount(s2)
+				}
+			})
+		})
+	}
+}
+
 func BenchmarkBitlist_And(b *testing.B) {
 	for n := uint64(0); n <= 2048; n += 256 {
 		b.Run(fmt.Sprintf("size:%d", n), func(b *testing.B) {


### PR DESCRIPTION
As outlined in the ["Future Work" section of the proposal](https://hackmd.io/ZpniBiWeSJu_lvANHCDxdQ?view#Future-work) one of the possible optimizations can be combining operations and summary methods into one i.e. instead of consecutive calls
```golang
cnt := b1.And(b2).Count() // b1, b2 are bitlists, 
                          // And() returns their intersection, Count() calculates the number of 1s
```
we can just
```golang
cnt := b1.AndCount(b2)
```

This combined version performs better as we do not update some bitlist first and then traverse it in search for 1s, but counting word intersections directly and incrementing the counter (this is true for even `NoAllocAnd()` where we are passing in a bitlist to update).

Here are benchmarks:
![image](https://user-images.githubusercontent.com/188194/105147782-b3dbd680-5b12-11eb-8f97-a4e1cba36432.png)
