### PR TITLE
Clear unused bits in Not()

### DIFF
--- a/bitlist64.go
+++ b/bitlist64.go
@@ -308,6 +308,7 @@ func (b *Bitlist64) NoAllocNot(ret *Bitlist64) {
 	for idx, word := range b.data {
 		ret.data[idx] = ^word
 	}
+	ret.clearUnusedBits()
 }
 
 // BitIndices returns list of bit indexes of bitlist where value is set to true.
@@ -366,4 +367,12 @@ func (b *Bitlist64) Clone() *Bitlist64 {
 // numWordsRequired calculates how many words are required to hold bitlist of n bits.
 func numWordsRequired(n uint64) int {
 	return int((n + (wordSize - 1)) >> wordSizeLog2)
+}
+
+// clearUnusedBits zeroes unused bits in the last word.
+func (b *Bitlist64) clearUnusedBits() {
+	// Unless bitlist is divisible by a word evenly, we need to zero unused bits in the last word.
+	if !(b.size%wordSize == 0) {
+		b.data[len(b.data)-1] &= allBitsSet >> (wordSize - b.size%wordSize)
+	}
 }

--- a/bitlist64_test.go
+++ b/bitlist64_test.go
@@ -1196,6 +1196,16 @@ func TestBitlist64_Not(t *testing.T) {
 			want: NewBitlist64From([]uint64{}),
 		},
 		{
+			// Last word bits are unused, single word.
+			a:    NewBitlist64(3),                  // 0b*****000
+			want: NewBitlist64From([]uint64{0x07}), // 0b00000111
+		},
+		{
+			// Last word bits are unused, multiple words.
+			a:    NewBitlist64(131),                                        // 0x00..00, 0x00..00, 0b*****000
+			want: NewBitlist64From([]uint64{allBitsSet, allBitsSet, 0x07}), // 0xFF..FF, 0xFF..FF, 0b00000111
+		},
+		{
 			a:    NewBitlist64From([]uint64{0x01}),               // 0b00000001
 			want: NewBitlist64From([]uint64{0xFFFFFFFFFFFFFFFE}), // 0b11111110
 		},
@@ -1252,7 +1262,7 @@ func TestBitlist64_Not(t *testing.T) {
 	t.Run("Not()", func(t *testing.T) {
 		for _, tt := range tests {
 			if !reflect.DeepEqual(tt.a.Not().data, tt.want.data) {
-				t.Errorf("(%+v).Not() = %x, wanted %x", tt.a, tt.a.Not().data, tt.want)
+				t.Errorf("(%+v).Not() = %x, wanted %x", tt.a, tt.a.Not().data, tt.want.data)
 			}
 		}
 	})


### PR DESCRIPTION
While `Bitlist64` is designed to be used with bitlists which have length that is multiple of 64 (that's bitlist which is evenly divided by the word length), adding support for bitlists of arbitrary lengths is not that hard: 
- For binary operations unused bits will not be updated while they are set to zero in both operands: `0 OR 0 = 0`, `0 XOR 0 = 0`, `0 AND 0 = 0`. Now, since setting bits that are outside of bitlist size is disallowed in `SetBitAt()` - we can safely assume that unused bits will remain zeroed for available binary operations.
-  For the only unary operation `Not()` we need to make sure that unused bits are cleared i.e. if we have `0x05` (last byte thus being `0b00000101`) and the bitlist of length 3 bits, we need to make sure that on `Not()` such a bitlist will produce `0x02` (last byte `0b00000010` where last 3 bits are negated `101 -> 010`, and unused bits are untouched). That's unused bits are not set to 1, and we do not end up with `0xFC` - last byte `0b11111010`.

This PR adds such bit cleaning functionality to `Not()`. I've kept unit tests at 100% coverage + checked benchmarks. 

On benchmarks: 
- With bitlists aligning to wordsize difference is totally unnoticeable (sth like +- `0.1ns/op` which also changes if I do not use bit cleaning at all and re-run non-modified test several times -- so, it is on the level of statistical error)
- With bitlist of different size the difference is around `+1ns/op` (from `15.9ns/op -> 16.8ns/op`), so is still a nice trade-off.