### PR TITLE
Add bitlist.BytesNoTrim() method

### DIFF
--- a/bitlist.go
+++ b/bitlist.go
@@ -110,6 +110,30 @@ func (b Bitlist) Bytes() []byte {
 	return ret[:newLen]
 }
 
+// BytesNoTrim returns the underlying byte array without the length bit.
+// No trimming of leading zeros occurs, only size bit is cleared.
+func (b Bitlist) BytesNoTrim() []byte {
+	if len(b) == 0 {
+		return []byte{}
+	}
+
+	lenB := len(b)
+	ret := make([]byte, lenB)
+	copy(ret, b)
+
+	// If last byte contains only size bit, return without that byte.
+	if ret[lenB-1] == 0x0 || ret[lenB-1] == 0x1 {
+		return ret[:lenB-1]
+	}
+
+	// Clear the most significant bit (the length bit).
+	msb := uint8(bits.Len8(ret[len(ret)-1])) - 1
+	clearBit := uint8(1 << msb)
+	ret[len(ret)-1] &^= clearBit
+
+	return ret
+}
+
 // Count returns the number of 1s in the bitlist.
 func (b Bitlist) Count() uint64 {
 	c := 0

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -363,6 +363,69 @@ func TestBitlist_Bytes(t *testing.T) {
 	}
 }
 
+func TestBitlist_BytesNoTrim(t *testing.T) {
+	tests := []struct {
+		bitlist Bitlist
+		want    []byte
+	}{
+		{
+			bitlist: Bitlist{},
+			want:    []byte{},
+		},
+		{
+			bitlist: Bitlist{0x00},
+			want:    []byte{},
+		},
+		{
+			bitlist: Bitlist{0x01},
+			want:    []byte{},
+		},
+		{
+			bitlist: Bitlist{0x02},
+			want:    []byte{0x00},
+		},
+		{
+			bitlist: Bitlist{0x03},
+			want:    []byte{0x01},
+		},
+		{
+			bitlist: Bitlist{0x12},
+			want:    []byte{0x02},
+		},
+		{
+			bitlist: Bitlist{0x02, 0x01},
+			want:    []byte{0x02},
+		},
+		{
+			bitlist: Bitlist{0x02, 0x02},
+			want:    []byte{0x02, 0x00},
+		},
+		{
+			bitlist: Bitlist{0x02, 0x03},
+			want:    []byte{0x02, 0x01},
+		},
+		{
+			bitlist: Bitlist{0x01, 0x00, 0x08},
+			want:    []byte{0x01, 0x00, 0x00},
+		},
+		{
+			bitlist: Bitlist{0x00, 0x00, 0x02},
+			want:    []byte{0x00, 0x00, 0x00},
+		},
+		{
+			bitlist: Bitlist{0x00, 0x00, 0x01},
+			want:    []byte{0x00, 0x00},
+		},
+	}
+
+	for _, tt := range tests {
+		got := tt.bitlist.BytesNoTrim()
+		if !bytes.Equal(got, tt.want) {
+			t.Errorf("(%#x).BytesNoTrim() = %#v, wanted %#v", tt.bitlist, got, tt.want)
+		}
+	}
+}
+
 func TestBitlist_Count(t *testing.T) {
 	tests := []struct {
 		bitlist Bitlist


### PR DESCRIPTION
- When working on https://github.com/prysmaticlabs/prysm/pull/7938 in order to make sure that new optimized attestation aggregation is behind the flag (so that upgrade is smooth and safe), we need to convert from `Bitlist` to `Bitlist64` (the new type that optimized implementation is using).
- We have `Bitlist.Bytes()` method, and I've added `Bitlist64.NewBitlist64FromBytes([]byte)` for easy and optimal conversion, however there's an issue (which took me lots of time to uncover 😢 ): `Bytes()` trims leading zeroes, thus changing the size of the bitlist used for aggregation (and the new size depends on which bits are on).
- To solve that problem, `Bitlist.BytesNoTrim()` method is being introduced in this PR. This method is very similar to `Bytes`, which returns underlying bytes array, with some changes:
  - Size bit is removed, if the last byte holds only size bit (w/o any more info), that byte is dropped.
  - The original size of the bytes array is preserved, disregarding if any bytes contain zero values.