### PR TITLE
Add or and overlaps for bit vector 128

### DIFF
--- a/bitvector128.go
+++ b/bitvector128.go
@@ -139,3 +139,29 @@ func (b Bitvector128) Contains(c Bitvector128) bool {
 
 	return true
 }
+
+// Overlaps returns true if the bitlist contains one of the bits from the provided argument
+// bitlist. This method will panic if bitlists are not the same length.
+func (b Bitvector128) Overlaps(c Bitvector128) bool {
+	lenB, lenC := b.Len(), c.Len()
+	if lenB != lenC {
+		panic("bitlists are different lengths")
+	}
+
+	if lenB == 0 || lenC == 0 {
+		return false
+	}
+
+	// To ensure all of the bits in c are not overlapped in b, we iterate over every byte, invert b
+	// and xor the byte from b and c, then and it against c. If the result is non-zero, then
+	// we can be assured that byte in c had bits not overlapped in b.
+	for i := 0; i < len(b); i++ {
+		// If this byte is the last byte in the array, mask the length bit.
+		mask := uint8(0xFF)
+
+		if (^b[i]^c[i])&c[i]&mask != 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/bitvector128.go
+++ b/bitvector128.go
@@ -165,3 +165,17 @@ func (b Bitvector128) Overlaps(c Bitvector128) bool {
 	}
 	return false
 }
+
+// Or returns the OR result of the two bitfields. This method will panic if the bitlists are not the same length.
+func (b Bitvector128) Or(c Bitvector128) Bitlist {
+	if b.Len() != c.Len() {
+		panic("bitlists are different lengths")
+	}
+
+	ret := make([]byte, len(b))
+	for i := 0; i < len(b); i++ {
+		ret[i] = b[i] | c[i]
+	}
+
+	return ret
+}

--- a/bitvector128_test.go
+++ b/bitvector128_test.go
@@ -511,3 +511,64 @@ func TestBitvector128_Overlaps(t *testing.T) {
 		}
 	}
 }
+
+func TestBitVector128_Or(t *testing.T) {
+	tests := []struct {
+		a    Bitvector128
+		b    Bitvector128
+		want Bitvector128
+	}{
+		{
+			a:    Bitvector128{0x02}, // 0b00000010
+			b:    Bitvector128{0x03}, // 0b00000011
+			want: Bitvector128{0x03}, // 0b00000011
+		},
+		{
+			a:    Bitvector128{0x03}, // 0b00000011
+			b:    Bitvector128{0x03}, // 0b00000011
+			want: Bitvector128{0x03}, // 0b00000011
+		},
+		{
+			a:    Bitvector128{0x13}, // 0b00010011
+			b:    Bitvector128{0x15}, // 0b00010101
+			want: Bitvector128{0x17}, // 0b00010111
+		},
+		{
+			a:    Bitvector128{0x1F}, // 0b00011111
+			b:    Bitvector128{0x13}, // 0b00010011
+			want: Bitvector128{0x1F}, // 0b00011111
+		},
+		{
+			a:    Bitvector128{0x1F, 0x03}, // 0b00011111, 0b00000011
+			b:    Bitvector128{0x13, 0x02}, // 0b00010011, 0b00000010
+			want: Bitvector128{0x1F, 0x03}, // 0b00011111, 0b00000011
+		},
+		{
+			a:    Bitvector128{0x1F, 0x01}, // 0b00011111, 0b00000001
+			b:    Bitvector128{0x93, 0x01}, // 0b10010011, 0b00000001
+			want: Bitvector128{0x9F, 0x01}, // 0b00011111, 0b00000001
+		},
+		{
+			a:    Bitvector128{0xFF, 0x02}, // 0b11111111, 0x00000010
+			b:    Bitvector128{0x13, 0x03}, // 0b00010011, 0x00000011
+			want: Bitvector128{0xFF, 0x03}, // 0b11111111, 0x00000011
+		},
+		{
+			a:    Bitvector128{0xFF, 0x85}, // 0b11111111, 0x10000111
+			b:    Bitvector128{0x13, 0x8F}, // 0b00010011, 0x10001111
+			want: Bitvector128{0xFF, 0x8F}, // 0b11111111, 0x10001111
+		},
+	}
+
+	for _, tt := range tests {
+		if !bytes.Equal(tt.a.Or(tt.b), tt.want) {
+			t.Errorf(
+				"(%x).Or(%x) = %x, wanted %x",
+				tt.a,
+				tt.b,
+				tt.a.Or(tt.b),
+				tt.want,
+			)
+		}
+	}
+}

--- a/bitvector128_test.go
+++ b/bitvector128_test.go
@@ -449,3 +449,65 @@ func TestBitvector128_Contains(t *testing.T) {
 		}
 	}
 }
+
+func TestBitvector128_Overlaps(t *testing.T) {
+	tests := []struct {
+		a    Bitvector128
+		b    Bitvector128
+		want bool
+	}{
+		{
+			a:    Bitvector128{0x06}, // 0b00000110
+			b:    Bitvector128{0x01}, // 0b00000101
+			want: false,
+		},
+		{
+			a:    Bitvector128{0x06}, // 0b00000110
+			b:    Bitvector128{0x05}, // 0b00000101
+			want: true,
+		},
+		{
+			a:    Bitvector128{0x1A}, // 0b00011010
+			b:    Bitvector128{0x25}, // 0b00100101
+			want: false,
+		},
+		{
+			a:    Bitvector128{0x1F}, // 0b00011111
+			b:    Bitvector128{0x11}, // 0b00010001
+			want: true,
+		},
+		{
+			a:    Bitvector128{0xFF, 0x85}, // 0b11111111, 0b10000111
+			b:    Bitvector128{0x13, 0x8F}, // 0b00010011, 0b10001111
+			want: true,
+		},
+		{
+			a:    Bitvector128{0x00, 0x40}, // 0b00000001, 0b01000000
+			b:    Bitvector128{0x00, 0x40}, // 0b00000010, 0b01000000
+			want: true,
+		},
+		{
+			a:    Bitvector128{0x01, 0x40}, // 0b00000001, 0b01000000
+			b:    Bitvector128{0x02, 0x30}, // 0b00000010, 0b01000000
+			want: false,
+		},
+		{
+			a:    Bitvector128{0x01, 0x01, 0x01}, // 0b00000001, 0b00000001, 0b00000001
+			b:    Bitvector128{0x02, 0x00, 0x00}, // 0b00000010, 0b00000000, 0b00000001
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		result := tt.a.Overlaps(tt.b)
+		if result != tt.want {
+			t.Errorf(
+				"(%x).Overlaps(%x) = %t, wanted %t",
+				tt.a,
+				tt.b,
+				result,
+				tt.want,
+			)
+		}
+	}
+}


### PR DESCRIPTION
Add a method to check for `overlap` and `or` for bit vector 128 to be used for Altair

