### PR TITLE
Remove panic paths from bitvector/bitlist

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "bitvector64.go",
         "bitvector8.go",
         "doc.go",
+        "errors.go",
         "min.go",
     ],
     importpath = "github.com/prysmaticlabs/go-bitfield",

--- a/bitlist_bench_test.go
+++ b/bitlist_bench_test.go
@@ -337,8 +337,10 @@ func BenchmarkBitlist_OrCount(b *testing.B) {
 				}
 				b.StartTimer()
 				for i := 0; i < b.N; i++ {
-					s.Or(s1).Count()
-					s.Or(s2).Count()
+					a, _ := s.Or(s1)
+					a.Count()
+					b, _ := s.Or(s2)
+					b.Count()
 				}
 			})
 			b.Run("[]uint64", func(b *testing.B) {
@@ -353,8 +355,10 @@ func BenchmarkBitlist_OrCount(b *testing.B) {
 				}
 				b.StartTimer()
 				for i := 0; i < b.N; i++ {
-					s.Or(s1).Count()
-					s.Or(s2).Count()
+					a, _ := s.Or(s1)
+					a.Count()
+					b, _ := s.Or(s2)
+					b.Count()
 				}
 			})
 			b.Run("[]uint64 (noalloc)", func(b *testing.B) {
@@ -467,8 +471,10 @@ func BenchmarkBitlist_AndCount(b *testing.B) {
 				}
 				b.StartTimer()
 				for i := 0; i < b.N; i++ {
-					s.And(s1).Count()
-					s.And(s2).Count()
+					a, _ := s.And(s1)
+					a.Count()
+					b, _ := s.And(s2)
+					b.Count()
 				}
 			})
 			b.Run("[]uint64", func(b *testing.B) {
@@ -483,8 +489,10 @@ func BenchmarkBitlist_AndCount(b *testing.B) {
 				}
 				b.StartTimer()
 				for i := 0; i < b.N; i++ {
-					s.And(s1).Count()
-					s.And(s2).Count()
+					a, _ := s.And(s1)
+					a.Count()
+					b, _ := s.And(s2)
+					b.Count()
 				}
 			})
 			b.Run("[]uint64 (noalloc)", func(b *testing.B) {
@@ -597,8 +605,10 @@ func BenchmarkBitlist_XorCount(b *testing.B) {
 				}
 				b.StartTimer()
 				for i := 0; i < b.N; i++ {
-					s.Xor(s1).Count()
-					s.Xor(s2).Count()
+					a, _ := s.Xor(s1)
+					a.Count()
+					b, _ := s.Xor(s2)
+					b.Count()
 				}
 			})
 			b.Run("[]uint64", func(b *testing.B) {
@@ -613,8 +623,10 @@ func BenchmarkBitlist_XorCount(b *testing.B) {
 				}
 				b.StartTimer()
 				for i := 0; i < b.N; i++ {
-					s.Xor(s1).Count()
-					s.Xor(s2).Count()
+					a, _ := s.Xor(s1)
+					a.Count()
+					b, _ := s.Xor(s2)
+					b.Count()
 				}
 			})
 			b.Run("[]uint64 (noalloc)", func(b *testing.B) {

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -499,7 +499,10 @@ func TestBitlist_ToBitlist64(t *testing.T) {
 		wanted := createBitlist64(tt.size, tt.selectedIndices)
 		t.Run(fmt.Sprintf("size:%d,indices:%v", tt.size, tt.selectedIndices), func(t *testing.T) {
 			// Convert to Bitlist64.
-			got := source.ToBitlist64()
+			got, err := source.ToBitlist64()
+			if err != nil {
+				t.Error(err)
+			}
 			if !reflect.DeepEqual(got, wanted) {
 				t.Errorf("ToBitlist64(%#x) = %#b, wanted %#b", source, got, wanted)
 			}
@@ -624,12 +627,13 @@ func TestBitlist_Contains(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if tt.a.Contains(tt.b) != tt.want {
+		if got, err := tt.a.Contains(tt.b); got != tt.want || err != nil {
 			t.Errorf(
-				"(%x).Contains(%x) = %t, wanted %t",
+				"(%x).Contains(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
-				tt.a.Contains(tt.b),
+				got,
+				err,
 				tt.want,
 			)
 		}
@@ -695,13 +699,13 @@ func TestBitlist_Overlaps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := tt.a.Overlaps(tt.b)
-		if result != tt.want {
+		if result, err := tt.a.Overlaps(tt.b); result != tt.want || err != nil{
 			t.Errorf(
-				"(%x).Overlaps(%x) = %t, wanted %t",
+				"(%x).Overlaps(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
 				result,
+				err,
 				tt.want,
 			)
 		}
@@ -757,12 +761,13 @@ func TestBitlist_Or(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if !bytes.Equal(tt.a.Or(tt.b), tt.want) {
+		if got, err := tt.a.Or(tt.b); !bytes.Equal(got, tt.want)  || err != nil{
 			t.Errorf(
-				"(%x).Or(%x) = %x, wanted %x",
+				"(%x).Or(%x) = %x, %v, wanted %x",
 				tt.a,
 				tt.b,
-				tt.a.Or(tt.b),
+				got, 
+				err,
 				tt.want,
 			)
 		}
@@ -818,12 +823,13 @@ func TestBitlist_And(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if !bytes.Equal(tt.a.And(tt.b), tt.want) {
+		if got, err := tt.a.And(tt.b); !bytes.Equal(got, tt.want) || err != nil {
 			t.Errorf(
-				"(%x).And(%x) = %x, wanted %x",
+				"(%x).And(%x) = %x, %v, wanted %x",
 				tt.a,
 				tt.b,
-				tt.a.And(tt.b),
+				got,
+				err,
 				tt.want,
 			)
 		}
@@ -880,12 +886,13 @@ func TestBitlist_Xor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("(%x).Xor(%x)", tt.a, tt.b), func(t *testing.T) {
-			if !bytes.Equal(tt.a.Xor(tt.b), tt.want) {
+			if got, err := tt.a.Xor(tt.b); !bytes.Equal(got, tt.want) || err != nil {
 				t.Errorf(
-					"(%x).Xor(%x) = %x, wanted %x",
+					"(%x).Xor(%x) = %x, %v, wanted %x",
 					tt.a,
 					tt.b,
-					tt.a.Xor(tt.b),
+					got, 
+					err,
 					tt.want,
 				)
 			}

--- a/bitlist_test.go
+++ b/bitlist_test.go
@@ -699,7 +699,7 @@ func TestBitlist_Overlaps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if result, err := tt.a.Overlaps(tt.b); result != tt.want || err != nil{
+		if result, err := tt.a.Overlaps(tt.b); result != tt.want || err != nil {
 			t.Errorf(
 				"(%x).Overlaps(%x) = %t, %v, wanted %t",
 				tt.a,
@@ -761,12 +761,12 @@ func TestBitlist_Or(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got, err := tt.a.Or(tt.b); !bytes.Equal(got, tt.want)  || err != nil{
+		if got, err := tt.a.Or(tt.b); !bytes.Equal(got, tt.want) || err != nil {
 			t.Errorf(
 				"(%x).Or(%x) = %x, %v, wanted %x",
 				tt.a,
 				tt.b,
-				got, 
+				got,
 				err,
 				tt.want,
 			)
@@ -891,7 +891,7 @@ func TestBitlist_Xor(t *testing.T) {
 					"(%x).Xor(%x) = %x, %v, wanted %x",
 					tt.a,
 					tt.b,
-					got, 
+					got,
 					err,
 					tt.want,
 				)

--- a/bitvector128.go
+++ b/bitvector128.go
@@ -122,10 +122,10 @@ func (b Bitvector128) BitIndices() []int {
 }
 
 // Contains returns true if the bitlist contains all of the bits from the provided argument
-// bitlist. This method will panic if bitlists are not the same length.
-func (b Bitvector128) Contains(c Bitvector128) bool {
+// bitlist. This method will return an error if bitlists are not the same length.
+func (b Bitvector128) Contains(c Bitvector128) (bool, error) {
 	if b.Len() != c.Len() {
-		panic("bitvector are different lengths")
+		return false, ErrBitvectorDifferentLength
 	}
 
 	// To ensure all of the bits in c are present in b, we iterate over every byte, combine
@@ -133,23 +133,23 @@ func (b Bitvector128) Contains(c Bitvector128) bool {
 	// are assured that a byte in c had bits not present in b.
 	for i := 0; i < len(b); i++ {
 		if b[i]^(b[i]|c[i]) != 0 {
-			return false
+			return false, nil
 		}
 	}
 
-	return true
+	return true, nil
 }
 
 // Overlaps returns true if the bitlist contains one of the bits from the provided argument
-// bitlist. This method will panic if bitlists are not the same length.
-func (b Bitvector128) Overlaps(c Bitvector128) bool {
+// bitlist. This method will return an error if bitlists are not the same length.
+func (b Bitvector128) Overlaps(c Bitvector128) (bool, error) {
 	lenB, lenC := b.Len(), c.Len()
-	if lenB != lenC {
-		panic("bitlists are different lengths")
+	if b.Len() != c.Len() {
+		return false, ErrBitvectorDifferentLength
 	}
 
 	if lenB == 0 || lenC == 0 {
-		return false
+		return false, nil
 	}
 
 	// To ensure all of the bits in c are not overlapped in b, we iterate over every byte, invert b
@@ -160,16 +160,16 @@ func (b Bitvector128) Overlaps(c Bitvector128) bool {
 		mask := uint8(0xFF)
 
 		if (^b[i]^c[i])&c[i]&mask != 0 {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-// Or returns the OR result of the two bitfields. This method will panic if the bitlists are not the same length.
-func (b Bitvector128) Or(c Bitvector128) Bitvector128 {
+// Or returns the OR result of the two bitfields. This method will return an error if the bitlists are not the same length.
+func (b Bitvector128) Or(c Bitvector128) (Bitvector128, error) {
 	if b.Len() != c.Len() {
-		panic("bitlists are different lengths")
+		return nil, ErrBitvectorDifferentLength
 	}
 
 	ret := make([]byte, len(b))
@@ -177,5 +177,5 @@ func (b Bitvector128) Or(c Bitvector128) Bitvector128 {
 		ret[i] = b[i] | c[i]
 	}
 
-	return ret
+	return ret, nil
 }

--- a/bitvector128_test.go
+++ b/bitvector128_test.go
@@ -438,12 +438,13 @@ func TestBitvector128_Contains(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if tt.a.Contains(tt.b) != tt.want {
+		if got, err := tt.a.Contains(tt.b); got != tt.want || err != nil {
 			t.Errorf(
-				"(%x).Contains(%x) = %t, wanted %t",
+				"(%x).Contains(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
-				tt.a.Contains(tt.b),
+				got, 
+				err,
 				tt.want,
 			)
 		}
@@ -499,13 +500,13 @@ func TestBitvector128_Overlaps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := tt.a.Overlaps(tt.b)
-		if result != tt.want {
+		if got, err := tt.a.Overlaps(tt.b); got != tt.want || err != nil {
 			t.Errorf(
-				"(%x).Overlaps(%x) = %t, wanted %t",
+				"(%x).Overlaps(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
-				result,
+				got,
+				err,
 				tt.want,
 			)
 		}
@@ -561,12 +562,13 @@ func TestBitVector128_Or(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if !bytes.Equal(tt.a.Or(tt.b), tt.want) {
+		if got, err := tt.a.Or(tt.b); !bytes.Equal(got, tt.want) {
 			t.Errorf(
-				"(%x).Or(%x) = %x, wanted %x",
+				"(%x).Or(%x) = %x, %v, wanted %x",
 				tt.a,
 				tt.b,
-				tt.a.Or(tt.b),
+				got,
+				err,
 				tt.want,
 			)
 		}

--- a/bitvector128_test.go
+++ b/bitvector128_test.go
@@ -443,7 +443,7 @@ func TestBitvector128_Contains(t *testing.T) {
 				"(%x).Contains(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
-				got, 
+				got,
 				err,
 				tt.want,
 			)

--- a/bitvector8.go
+++ b/bitvector8.go
@@ -93,45 +93,44 @@ func (b Bitvector8) BitIndices() []int {
 }
 
 // Contains returns true if the bitlist contains all of the bits from the provided argument
-// bitlist. This method will panic if bitlists are not the same length or not `bitvector8BitSize`.
-func (b Bitvector8) Contains(c Bitvector8) bool {
+// bitlist. This method will return an error if bitlists are not the same length or not `bitvector8BitSize`.
+func (b Bitvector8) Contains(c Bitvector8) (bool, error) {
 	if b.Len() != c.Len() {
-		panic("bitvector are different lengths")
+		return false, ErrBitvectorDifferentLength
 	}
 	if b.Len() != bitvector8BitSize {
-		panic("bitvector size is not bitvector8BitSize")
+		return false, ErrWrongLen
 	}
 
 	// Combine the byte from b and c, then XOR them against b. If the result of this is non-zero, then we
 	// are assured that a byte in c had bits not present in b.
-	return b[0]^(b[0]|c[0]) == 0
+	return b[0]^(b[0]|c[0]) == 0, nil
 }
 
 // Overlaps returns true if the bitlist contains one of the bits from the provided argument
-// bitlist. This method will panic if bitlists are not the same length.
-func (b Bitvector8) Overlaps(c Bitvector8) bool {
-	lenB, lenC := b.Len(), c.Len()
-	if lenB != lenC {
-		panic("bitlists are different lengths")
+// bitlist. This method will return an error if bitlists are not the same length.
+func (b Bitvector8) Overlaps(c Bitvector8) (bool, error) {
+	if b.Len() != c.Len() {
+		return false, ErrBitvectorDifferentLength
 	}
-	if lenB != bitvector8BitSize {
-		panic("bitvector size is not bitvector8BitSize")
+	if b.Len() != bitvector8BitSize {
+		return false, ErrWrongLen
 	}
 
 	// Invert b and xor the byte from b and c, then and it against c. If the result is non-zero, then
 	// we can be assured that byte in c had bits not overlapped in b.
 	mask := uint8(0xFF)
-	return (^b[0]^c[0])&c[0]&mask != 0
+	return (^b[0]^c[0])&c[0]&mask != 0, nil
 }
 
-// Or returns the OR result of the two bitfields. This method will panic if the bitlists are not the same length.
-func (b Bitvector8) Or(c Bitvector8) Bitvector8 {
+// Or returns the OR result of the two bitfields. This method will return an error if the bitlists are not the same length.
+func (b Bitvector8) Or(c Bitvector8) (Bitvector8, error) {
 	if b.Len() != c.Len() {
-		panic("bitlists are different lengths")
+		return nil, ErrBitvectorDifferentLength
 	}
 	if b.Len() != bitvector8BitSize {
-		panic("bitvector size is not bitvector8BitSize")
+		return nil, ErrWrongLen
 	}
 
-	return []byte{b[0] | c[0]}
+	return []byte{b[0] | c[0]}, nil
 }

--- a/bitvector8_test.go
+++ b/bitvector8_test.go
@@ -337,12 +337,13 @@ func TestBitvector8_Contains(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if tt.a.Contains(tt.b) != tt.want {
+		if got, err := tt.a.Contains(tt.b); got != tt.want || err != nil {
 			t.Errorf(
-				"(%x).Contains(%x) = %t, wanted %t",
+				"(%x).Contains(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
-				tt.a.Contains(tt.b),
+				got, 
+				err,
 				tt.want,
 			)
 		}
@@ -378,13 +379,13 @@ func TestBitvector8_Overlaps(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := tt.a.Overlaps(tt.b)
-		if result != tt.want {
+		if got, err := tt.a.Overlaps(tt.b); got != tt.want || err != nil {
 			t.Errorf(
-				"(%x).Overlaps(%x) = %t, wanted %t",
+				"(%x).Overlaps(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
-				result,
+				got,
+				err,
 				tt.want,
 			)
 		}
@@ -420,12 +421,13 @@ func TestBitVector8_Or(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if !bytes.Equal(tt.a.Or(tt.b), tt.want) {
+		if got, err := tt.a.Or(tt.b); !bytes.Equal(got, tt.want) || err != nil {
 			t.Errorf(
-				"(%x).Or(%x) = %x, wanted %x",
+				"(%x).Or(%x) = %x, %v, wanted %x",
 				tt.a,
 				tt.b,
-				tt.a.Or(tt.b),
+				got, 
+				err,
 				tt.want,
 			)
 		}

--- a/bitvector8_test.go
+++ b/bitvector8_test.go
@@ -342,7 +342,7 @@ func TestBitvector8_Contains(t *testing.T) {
 				"(%x).Contains(%x) = %t, %v, wanted %t",
 				tt.a,
 				tt.b,
-				got, 
+				got,
 				err,
 				tt.want,
 			)
@@ -426,7 +426,7 @@ func TestBitVector8_Or(t *testing.T) {
 				"(%x).Or(%x) = %x, %v, wanted %x",
 				tt.a,
 				tt.b,
-				got, 
+				got,
 				err,
 				tt.want,
 			)

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,7 @@
+package bitfield
+
+import "errors"
+
+var (
+	ErrBitlistDifferentLength = errors.New("bitlists are different lengths")
+)

--- a/errors.go
+++ b/errors.go
@@ -3,5 +3,7 @@ package bitfield
 import "errors"
 
 var (
-	ErrBitlistDifferentLength = errors.New("bitlists are different lengths")
+	ErrBitlistDifferentLength   = errors.New("bitlists are different lengths")
+	ErrBitvectorDifferentLength = errors.New("bitvectors are different lengths")
+	ErrWrongLen                 = errors.New("bitvector is wrong length")
 )


### PR DESCRIPTION
Removes all panic calls to replace with error returns.
